### PR TITLE
Use consistent naming in logs and stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ dep:
 	docker run -ti \
         --mount src="$(DIR)",target="$(DIR)",type="bind" \
         -w "$(DIR)" \
-		-e "GOPROXY=https://gocenter.io" \
+        -e "GOPROXY=https://gocenter.io" \
         asecurityteam/sdcli:v1 go dep
 
 lint:

--- a/pkg/domain/filter.go
+++ b/pkg/domain/filter.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Asset contains the key fields from a Nexpose asset
+// Asset contains the key fields from a Nexpose asset.
 type Asset struct {
 	LastScanned time.Time
 	Hostname    string
@@ -14,7 +14,7 @@ type Asset struct {
 }
 
 // Vulnerability contains the key fields from a Nexpose vulnerability associated with a
-// particular Asset
+// particular Asset.
 type Vulnerability struct {
 	ID             string
 	Results        []AssessmentResult
@@ -26,13 +26,13 @@ type Vulnerability struct {
 	Solutions      []string
 }
 
-// AssessmentResult contains port and protocol information for the Vulnerability
+// AssessmentResult contains port and protocol information for the Vulnerability.
 type AssessmentResult struct {
 	Port     int
 	Protocol string
 }
 
-// VulnerabilityFilter is an interface for filtering an asset's vulnerabilities based on configurable criteria
+// VulnerabilityFilter is an interface for filtering an asset's vulnerabilities based on configurable criteria.
 type VulnerabilityFilter interface {
 	FilterVulnerabilities(context.Context, Asset, []Vulnerability) []Vulnerability
 }

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -59,7 +59,7 @@ func (v *VulnerabilityFilterComponent) New(_ context.Context, c *VulnerabilityFi
 	}, nil
 }
 
-// VulnerabilityFilter implements the VulnerabilityFilter interface
+// VulnerabilityFilter implements the VulnerabilityFilter interface.
 type VulnerabilityFilter struct {
 	CVSSV2MinimumScore float64
 	VulnIDRegexp       *regexp.Regexp
@@ -95,7 +95,7 @@ func (f VulnerabilityFilter) FilterVulnerabilities(ctx context.Context, asset do
 		case vuln.CvssV2Score > f.CVSSV2MinimumScore:
 			filteredVulnerabilities = append(filteredVulnerabilities, vuln)
 			logger.Info(logs.VulnerabilityFiltered{
-				Action:  logs.VulnRetained,
+				Action:  logs.VulnAccepted,
 				Method:  logs.CvssV2Score,
 				VulnID:  vuln.ID,
 				AssetID: asset.ID,
@@ -105,7 +105,7 @@ func (f VulnerabilityFilter) FilterVulnerabilities(ctx context.Context, asset do
 		case f.VulnIDRegexp.MatchString(vuln.ID):
 			filteredVulnerabilities = append(filteredVulnerabilities, vuln)
 			logger.Info(logs.VulnerabilityFiltered{
-				Action:  logs.VulnRetained,
+				Action:  logs.VulnAccepted,
 				Method:  logs.VulnID,
 				VulnID:  vuln.ID,
 				AssetID: asset.ID,

--- a/pkg/handlers/v1/filter.go
+++ b/pkg/handlers/v1/filter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NexposeAssetVulnerabilitiesEvent is a Nexpose asset response payload appended
-// with assetVulnerabilityDetails
+// with assetVulnerabilityDetails.
 type NexposeAssetVulnerabilitiesEvent struct {
 	LastScanned     time.Time                   `json:"lastScanned"`
 	Hostname        string                      `json:"hostname"`
@@ -17,7 +17,7 @@ type NexposeAssetVulnerabilitiesEvent struct {
 	Vulnerabilities []AssetVulnerabilityDetails `json:"assetVulnerabilityDetails"`
 }
 
-// AssetVulnerabilityDetails contains the vulnerability information
+// AssetVulnerabilityDetails contains the vulnerability information.
 type AssetVulnerabilityDetails struct {
 	ID             string             `json:"id"`
 	Results        []AssessmentResult `json:"results"`
@@ -29,7 +29,7 @@ type AssetVulnerabilityDetails struct {
 	Solutions      []string           `json:"solutions"`
 }
 
-// AssessmentResult contains port and protocol information for the vulnerability
+// AssessmentResult contains port and protocol information for the vulnerability.
 type AssessmentResult struct {
 	Port     int    `json:"port"`
 	Protocol string `json:"protocol"`
@@ -37,7 +37,7 @@ type AssessmentResult struct {
 
 // FilterHandler accepts a payload with Nexpose asset information
 // and a list of vulnerabilities and returns a payload of the same shape
-// omitting vulnerabilities that do not meet the filter criteria
+// omitting vulnerabilities that do not meet the filter criteria.
 type FilterHandler struct {
 	VulnerabilityFilter domain.VulnerabilityFilter
 	Producer            domain.Producer

--- a/pkg/logs/filter.go
+++ b/pkg/logs/filter.go
@@ -1,17 +1,17 @@
 package logs
 
 const (
-	// VulnRetained is an Action used to signify the vuln was retained
-	VulnRetained = "retained"
-	// VulnDiscarded is an Action used to signify the vuln was discarded
+	// VulnAccepted is an Action used to signify the vuln was accepted.
+	VulnAccepted = "accepted"
+	// VulnDiscarded is an Action used to signify the vuln was discarded.
 	VulnDiscarded = "discarded"
-	// CvssV2Score signifies the method used to retain the vulnerability was the CVSS V2 Score
+	// CvssV2Score signifies the method used to retain the vulnerability was the CVSS V2 Score.
 	CvssV2Score = "cvss_v2_score"
-	// VulnID signifies the method used to retain the vulnerability was the vuln id
+	// VulnID signifies the method used to retain the vulnerability was the vuln id.
 	VulnID = "vuln_id"
 )
 
-// VulnerabilityFiltered contains details on the filtering of an asset's vulnerabilities
+// VulnerabilityFiltered contains details on the filtering of an asset's vulnerabilities.
 type VulnerabilityFiltered struct {
 	Message string `logevent:"message,default=vulnerability-filtered"`
 	Action  string `logevent:"action"`


### PR DESCRIPTION
Use the same language in the logs and stats for vulnerabilities that meet the acceptable filtering criteria. Also adds periods to all comments