### PR TITLE
Use GOPROXY in Dockerfile to get Docker Hub builds to pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM asecurityteam/sdcli:v1 AS BUILDER
 RUN mkdir -p /go/src/github.com/asecurityteam/nexpose-vuln-filter
 WORKDIR /go/src/github.com/asecurityteam/nexpose-vuln-filter
 COPY --chown=sdcli:sdcli . .
-RUN sdcli go dep
+RUN GOPROXY="https://gocenter.io" sdcli go dep
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o /opt/app main.go
 
 ##################################


### PR DESCRIPTION
Docker Hub builds are failing during the `make dep` stage due to the Apache thrift issue.

Docker Hub build log:
```bash
go: git.apache.org/thrift.git@v0.0.0-20180902110319-2566ecd5d999: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /go/pkg/mod/cache/vcs/83dba939f95a790e497d565fc4418400145a1a514f955fa052f662d56e920c3e: exit status 128:
fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
go: error loading module requirements
Removing intermediate container aa7966bc232f
The command '/bin/sh -c sdcli go dep' returned a non-zero code: 1
```