### PR TITLE
PSD-99 Add 'proof' to vuln info

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @asecurityteam/secdev
+*   @asecurityteam/prodsecdev

--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -201,3 +201,6 @@ components:
           type: string
           example: tcp
           description: The protocol of the service the result was discovered on.
+        proof:
+          type: string
+          description: The proof explaining why the result was found vulnerable.

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -204,6 +204,9 @@ components:
           type: string
           example: tcp
           description: The protocol of the service the result was discovered on.
+        proof:
+          type: string
+          description: The proof explaining why the result was found vulnerable.
     Error:
       type: object
       properties:

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,8 @@ require (
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da // indirect
 	github.com/lib/pq v1.2.0 // indirect
 	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nats-io/go-nats-streaming v0.4.4 // indirect
 	github.com/nats-io/nats-server v1.4.1 // indirect
 	github.com/nats-io/nkeys v0.1.0 // indirect

--- a/pkg/domain/filter.go
+++ b/pkg/domain/filter.go
@@ -30,6 +30,7 @@ type Vulnerability struct {
 type AssessmentResult struct {
 	Port     int
 	Protocol string
+	Proof    string
 }
 
 // VulnerabilityFilter is an interface for filtering an asset's vulnerabilities based on configurable criteria.

--- a/pkg/handlers/v1/filter.go
+++ b/pkg/handlers/v1/filter.go
@@ -33,6 +33,7 @@ type AssetVulnerabilityDetails struct {
 type AssessmentResult struct {
 	Port     int    `json:"port"`
 	Protocol string `json:"protocol"`
+	Proof    string `json:"proof"`
 }
 
 // FilterHandler accepts a payload with Nexpose asset information

--- a/pkg/handlers/v1/filter_test.go
+++ b/pkg/handlers/v1/filter_test.go
@@ -142,6 +142,7 @@ func TestVulnDetailsToVuln(t *testing.T) {
 						AssessmentResult{
 							Port:     80,
 							Protocol: "HTTP",
+							Proof:    "This is proof.",
 						},
 					},
 				},
@@ -153,6 +154,7 @@ func TestVulnDetailsToVuln(t *testing.T) {
 						domain.AssessmentResult{
 							Port:     80,
 							Protocol: "HTTP",
+							Proof:    "This is proof.",
 						},
 					},
 				},
@@ -203,6 +205,7 @@ func TestVulnToVulnDetails(t *testing.T) {
 						domain.AssessmentResult{
 							Port:     80,
 							Protocol: "HTTP",
+							Proof:    "This is proof.",
 						},
 					},
 				},
@@ -214,6 +217,7 @@ func TestVulnToVulnDetails(t *testing.T) {
 						AssessmentResult{
 							Port:     80,
 							Protocol: "HTTP",
+							Proof:    "This is proof.",
 						},
 					},
 				},


### PR DESCRIPTION
This change adds the "proof" field to the incoming and outgoing schema for Vulnerability Details so we can expose "proof" information in Nexpose VULN tickets.